### PR TITLE
Add edit and delete functionality to non-conformities

### DIFF
--- a/components/NonConformities.module.css
+++ b/components/NonConformities.module.css
@@ -296,6 +296,103 @@
   color: var(--text-secondary);
 }
 
+.date-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.action-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.edit-button,
+.delete-button {
+  padding: 8px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.edit-button {
+  background: #e3f2fd;
+  color: #1976d2;
+}
+
+.edit-button:hover {
+  background: #bbdefb;
+  color: #0d47a1;
+}
+
+.delete-button {
+  background: #ffebee;
+  color: #d32f2f;
+}
+
+.delete-button:hover {
+  background: #ffcdd2;
+  color: #b71c1c;
+}
+
+/* Delete Dialog */
+.delete-dialog {
+  background: white;
+  border-radius: 12px;
+  width: 90%;
+  max-width: 400px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+}
+
+.delete-header {
+  padding: 24px 24px 0 24px;
+}
+
+.delete-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.delete-content {
+  padding: 16px 24px;
+}
+
+.delete-message {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.delete-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  padding: 0 24px 24px 24px;
+}
+
+.confirm-delete-button {
+  padding: 12px 20px;
+  background: #d32f2f;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.confirm-delete-button:hover {
+  background: #b71c1c;
+}
+
 .date-info {
   font-style: italic;
 }
@@ -331,7 +428,15 @@
   .card-footer {
     flex-direction: column;
     align-items: flex-start;
-    gap: 8px;
+    gap: 12px;
+  }
+
+  .date-section {
+    align-self: stretch;
+  }
+
+  .action-buttons {
+    align-self: flex-end;
   }
 }
 

--- a/components/non-conformities.tsx
+++ b/components/non-conformities.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import AddIcon from "@mui/icons-material/Add";
 import CloseIcon from "@mui/icons-material/Close";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
 import styles from "./NonConformities.module.css";
 
 interface NonConformity {
@@ -46,6 +48,10 @@ export function NonConformities({ auditId }: NonConformitiesProps) {
   ]);
 
   const [showAddForm, setShowAddForm] = useState(false);
+  const [showEditForm, setShowEditForm] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [editingItem, setEditingItem] = useState<NonConformity | null>(null);
+  const [deletingItemId, setDeletingItemId] = useState<string | null>(null);
   const [newNonConformity, setNewNonConformity] = useState({
     title: "",
     description: "",
@@ -111,6 +117,62 @@ export function NonConformities({ auditId }: NonConformitiesProps) {
       severity: "minor",
     });
     setShowAddForm(false);
+  };
+
+  const handleEditNonConformity = (item: NonConformity) => {
+    setEditingItem(item);
+    setNewNonConformity({
+      title: item.title,
+      description: item.description,
+      clause: item.clause,
+      severity: item.severity,
+    });
+    setShowEditForm(true);
+  };
+
+  const handleUpdateNonConformity = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!editingItem) return;
+
+    const updatedItem: NonConformity = {
+      ...editingItem,
+      ...newNonConformity,
+    };
+
+    setNonConformities(
+      nonConformities.map((item) =>
+        item.id === editingItem.id ? updatedItem : item,
+      ),
+    );
+
+    setNewNonConformity({
+      title: "",
+      description: "",
+      clause: "",
+      severity: "minor",
+    });
+    setEditingItem(null);
+    setShowEditForm(false);
+  };
+
+  const handleDeleteNonConformity = (id: string) => {
+    setDeletingItemId(id);
+    setShowDeleteDialog(true);
+  };
+
+  const confirmDelete = () => {
+    if (deletingItemId) {
+      setNonConformities(
+        nonConformities.filter((item) => item.id !== deletingItemId),
+      );
+    }
+    setDeletingItemId(null);
+    setShowDeleteDialog(false);
+  };
+
+  const cancelDelete = () => {
+    setDeletingItemId(null);
+    setShowDeleteDialog(false);
   };
 
   return (
@@ -229,6 +291,159 @@ export function NonConformities({ auditId }: NonConformitiesProps) {
         </div>
       )}
 
+      {showEditForm && editingItem && (
+        <div className={styles["modal-overlay"]}>
+          <div className={styles["modal-content"]}>
+            <div className={styles["modal-header"]}>
+              <h3 className={styles["modal-title"]}>Editar No Conformidad</h3>
+              <button
+                onClick={() => {
+                  setShowEditForm(false);
+                  setEditingItem(null);
+                  setNewNonConformity({
+                    title: "",
+                    description: "",
+                    clause: "",
+                    severity: "minor",
+                  });
+                }}
+                className={styles["close-button"]}
+              >
+                <CloseIcon sx={{ fontSize: 20 }} />
+              </button>
+            </div>
+
+            <form
+              onSubmit={handleUpdateNonConformity}
+              className={styles["add-form"]}
+            >
+              <div className={styles["form-group"]}>
+                <label className={styles["form-label"]}>Título:</label>
+                <input
+                  type="text"
+                  value={newNonConformity.title}
+                  onChange={(e) =>
+                    setNewNonConformity({
+                      ...newNonConformity,
+                      title: e.target.value,
+                    })
+                  }
+                  className={styles["form-input"]}
+                  required
+                />
+              </div>
+
+              <div className={styles["form-group"]}>
+                <label className={styles["form-label"]}>Descripción:</label>
+                <textarea
+                  value={newNonConformity.description}
+                  onChange={(e) =>
+                    setNewNonConformity({
+                      ...newNonConformity,
+                      description: e.target.value,
+                    })
+                  }
+                  className={styles["form-textarea"]}
+                  rows={4}
+                  required
+                />
+              </div>
+
+              <div className={styles["form-row"]}>
+                <div className={styles["form-group"]}>
+                  <label className={styles["form-label"]}>Cláusula:</label>
+                  <input
+                    type="text"
+                    value={newNonConformity.clause}
+                    onChange={(e) =>
+                      setNewNonConformity({
+                        ...newNonConformity,
+                        clause: e.target.value,
+                      })
+                    }
+                    className={styles["form-input"]}
+                    placeholder="ej. A.9.4.3"
+                    required
+                  />
+                </div>
+
+                <div className={styles["form-group"]}>
+                  <label className={styles["form-label"]}>Severidad:</label>
+                  <select
+                    value={newNonConformity.severity}
+                    onChange={(e) =>
+                      setNewNonConformity({
+                        ...newNonConformity,
+                        severity: e.target.value as any,
+                      })
+                    }
+                    className={styles["form-select"]}
+                  >
+                    <option value="minor">Menor</option>
+                    <option value="major">Mayor</option>
+                    <option value="critical">Crítica</option>
+                  </select>
+                </div>
+              </div>
+
+              <div className={styles["form-actions"]}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowEditForm(false);
+                    setEditingItem(null);
+                    setNewNonConformity({
+                      title: "",
+                      description: "",
+                      clause: "",
+                      severity: "minor",
+                    });
+                  }}
+                  className={styles["cancel-button"]}
+                >
+                  Cancelar
+                </button>
+                <button type="submit" className={styles["submit-button"]}>
+                  Actualizar No Conformidad
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {showDeleteDialog && (
+        <div className={styles["modal-overlay"]}>
+          <div className={styles["delete-dialog"]}>
+            <div className={styles["delete-header"]}>
+              <h3 className={styles["delete-title"]}>Confirmar Eliminación</h3>
+            </div>
+
+            <div className={styles["delete-content"]}>
+              <p className={styles["delete-message"]}>
+                ¿Estás seguro de que deseas eliminar esta no conformidad? Esta
+                acción no se puede deshacer.
+              </p>
+            </div>
+
+            <div className={styles["delete-actions"]}>
+              <button
+                onClick={cancelDelete}
+                className={styles["cancel-button"]}
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={confirmDelete}
+                className={styles["confirm-delete-button"]}
+              >
+                Eliminar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className={styles["conformities-list"]}>
         {nonConformities.length === 0 ? (
           <div className={styles["empty-state"]}>
@@ -269,16 +484,34 @@ export function NonConformities({ auditId }: NonConformitiesProps) {
               </p>
 
               <div className={styles["card-footer"]}>
-                <span className={styles["date-info"]}>
-                  Encontrada el:{" "}
-                  {new Date(item.dateFound).toLocaleDateString("es-ES")}
-                </span>
-                {item.dateResolved && (
+                <div className={styles["date-section"]}>
                   <span className={styles["date-info"]}>
-                    Resuelta el:{" "}
-                    {new Date(item.dateResolved).toLocaleDateString("es-ES")}
+                    Encontrada el:{" "}
+                    {new Date(item.dateFound).toLocaleDateString("es-ES")}
                   </span>
-                )}
+                  {item.dateResolved && (
+                    <span className={styles["date-info"]}>
+                      Resuelta el:{" "}
+                      {new Date(item.dateResolved).toLocaleDateString("es-ES")}
+                    </span>
+                  )}
+                </div>
+                <div className={styles["action-buttons"]}>
+                  <button
+                    onClick={() => handleEditNonConformity(item)}
+                    className={styles["edit-button"]}
+                    title="Editar no conformidad"
+                  >
+                    <EditIcon sx={{ fontSize: 16 }} />
+                  </button>
+                  <button
+                    onClick={() => handleDeleteNonConformity(item.id)}
+                    className={styles["delete-button"]}
+                    title="Eliminar no conformidad"
+                  >
+                    <DeleteIcon sx={{ fontSize: 16 }} />
+                  </button>
+                </div>
               </div>
             </div>
           ))


### PR DESCRIPTION
Add edit and delete functionality to the non-conformities component.

Changes include:
- Add edit and delete buttons to each non-conformity card
- Implement edit modal with form to update existing non-conformities
- Add delete confirmation dialog
- Import EditIcon and DeleteIcon from Material-UI
- Add state management for edit/delete operations
- Style action buttons and delete dialog with CSS
- Reorganize card footer layout with date section and action buttons
- Add responsive styling for mobile devices

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8e04b0fde3e44d79a59d975130a31943/spark-field)

👀 [Preview Link](https://8e04b0fde3e44d79a59d975130a31943-spark-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8e04b0fde3e44d79a59d975130a31943</projectId>-->
<!--<branchName>spark-field</branchName>-->